### PR TITLE
Console Extension to add a right-click action to task sequence deployments to show all status messages.

### DIFF
--- a/src/Console/Extensions/Actions/172d85e7-bb7a-4479-a6a2-768f175b75cb/AllStatusMessagesForTsDeployment.xml
+++ b/src/Console/Extensions/Actions/172d85e7-bb7a-4479-a6a2-768f175b75cb/AllStatusMessagesForTsDeployment.xml
@@ -1,0 +1,21 @@
+<ActionDescription Class="Executable" DisplayName="ShowAllStatusMessages" MnemonicDisplayName="MnemonicShowAllStatusMessages" Description="ShowAllStatusMessagesDescription">
+    <ShowOn>
+        <string>DefaultContextualTab</string>  
+        <string>ContextMenu</string> 
+    </ShowOn>
+    <ResourceAssembly>
+        <Assembly>AdminUI.SystemStatus.dll</Assembly>
+        <Type>Microsoft.ConfigurationManagement.AdminConsole.SystemStatus.Properties.Resources.resources</Type>
+    </ResourceAssembly>
+    <ImagesDescription>
+        <ResourceAssembly>
+            <Assembly>AdminUI.UIResources.dll</Assembly>
+            <Type>Microsoft.ConfigurationManagement.AdminConsole.UIResources.Properties.Resources.resources</Type>
+        </ResourceAssembly>
+        <ImageResourceName>ShowMessages</ImageResourceName>
+    </ImagesDescription>
+    <Executable>
+        <FilePath>i386\statview.exe</FilePath>
+        <Parameters>/SMS:PROPERTY=401,"##SUB:DeploymentID##"</Parameters>
+    </Executable>
+</ActionDescription>


### PR DESCRIPTION
This extension is based on UserVoice feedback - https://configurationmanager.uservoice.com/forums/300492-ideas/suggestions/11605476-status-messages-in-the-sccm-console. When admin installs this extension, it adds a right-click action to task sequence deployments to Show all status messages.